### PR TITLE
Fixed deprecation warning

### DIFF
--- a/bin/tith.js
+++ b/bin/tith.js
@@ -31,7 +31,9 @@ function createTiAppFile(fromPath) {
 
 function copyFile(fromPath, toPath) {
     fs.readFile(fromPath, function (err, data) {
-        fs.writeFile(toPath, data);
+        fs.writeFile(toPath, data, (err) => {
+          if(err) throw err;
+        });
     });
 }
 


### PR DESCRIPTION
Fixed deprecation warning [DEP0013] that throws type error in Node version 10+

Addressed in issue #10 