### PR TITLE
Fix dependency issue with newer versions of node (12+)

### DIFF
--- a/bin/tith.js
+++ b/bin/tith.js
@@ -31,9 +31,11 @@ function createTiAppFile(fromPath) {
 
 function copyFile(fromPath, toPath) {
     fs.readFile(fromPath, function (err, data) {
-        fs.writeFile(toPath, data, (err) => {
-          if(err) throw err;
-        });
+        if (data) {
+            fs.writeFile(toPath, data, (err) => {
+                if(err) throw err;
+            });
+        }
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "commander": "^2.12.2",
-    "update-notifier": "^0.2.2"
+    "update-notifier": "^5.1.0"
   }
 }


### PR DESCRIPTION
Fixes the #13 issue with "graceful-fs" (deep dependency of "update-notifier", which was out-of-date).